### PR TITLE
Add name to get_flags url so reverse can be used

### DIFF
--- a/python-django/apps/flags/urls.py
+++ b/python-django/apps/flags/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from apps.flags.views import get_flags
 
 urlpatterns = [
-    path("", get_flags),
+    path("", get_flags, name="get_flags"),
 ]


### PR DESCRIPTION
Allows for the usage of the reverse function to get the url based on the view name

```python
>>> from django.urls import reverse
>>> reverse("get_flags")
'/api/v1/flags/'
```